### PR TITLE
fix(deps): update pytest to 9.0.3 for CVE-2025-71176

### DIFF
--- a/agentic_ai_framework/requirements.txt
+++ b/agentic_ai_framework/requirements.txt
@@ -42,7 +42,7 @@ croniter>=1.4.0
 structlog==23.2.0
 
 # Development and testing
-pytest==7.4.3
+pytest==9.0.3
 pytest-asyncio==0.21.1
 httpx==0.25.2
 


### PR DESCRIPTION
## Summary
- Updates pytest from 7.4.3 to 9.0.3
- Fixes CVE-2025-71176 (tmpdir handling vulnerability)

## Test plan
- [ ] CI passes