### PR TITLE
fix(deps): update python-multipart to 0.0.26 for CVE-2026-40347

### DIFF
--- a/agentic_ai_framework/requirements.txt
+++ b/agentic_ai_framework/requirements.txt
@@ -19,7 +19,7 @@ pydantic-settings==2.1.0
 jsonschema==4.21.1
 
 # File upload and form handling
-python-multipart==0.0.22
+python-multipart==0.0.26
 
 # Authentication and security (for future use)
 python-jose[cryptography]==3.3.0


### PR DESCRIPTION
## Summary
- Addresses Dependabot alert #39 — [GHSA-mj87-hwqh-73pj](https://github.com/advisories/GHSA-mj87-hwqh-73pj) (CVE-2026-40347)
- Medium severity (CVSS 5.3) DoS via crafted multipart preamble/epilogue data
- Patch-level bump: `python-multipart` 0.0.22 → 0.0.26

## Test plan
- [ ] CI passes
- [ ] No breaking changes in multipart form handling