### PR TITLE
fix(deps): update python-dotenv to 1.2.2 for CVE-2026-28684

### DIFF
--- a/agentic_ai_framework/requirements.txt
+++ b/agentic_ai_framework/requirements.txt
@@ -52,7 +52,7 @@ flake8==6.1.0
 isort==5.12.0
 
 # Environment variable management
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 
 # JSON handling
 orjson==3.11.6


### PR DESCRIPTION
## Summary
- Bumps `python-dotenv` from 1.0.0 to 1.2.2 in `agentic_ai_framework/requirements.txt`
- Resolves Dependabot alert #40 (GHSA-mf9w-mj56-hr94 / CVE-2026-28684, MEDIUM)

## Vulnerability
`set_key()` / `unset_key()` followed symlinks via a cross-device `shutil.move()` fallback, allowing a local attacker to overwrite arbitrary files writable by the application. Fixed in 1.2.2 by avoiding the cross-device rename, using `os.replace()`, and not following symlinks by default.

## Test plan
- [ ] CI passes on this branch