### PR TITLE
deps: batch 8 Dependabot bumps in one PR

### DIFF
--- a/agentic_ai_framework/requirements.txt
+++ b/agentic_ai_framework/requirements.txt
@@ -16,10 +16,10 @@ requests==2.32.4
 # Data validation and serialization
 pydantic==2.5.1
 pydantic-settings==2.1.0
-jsonschema==4.21.1
+jsonschema==4.26.0
 
 # File upload and form handling
-python-multipart==0.0.27
+python-multipart==0.0.28
 
 # Authentication and security (for future use)
 python-jose[cryptography]==3.5.0
@@ -33,7 +33,7 @@ aiosmtplib==3.0.1
 # These are built into Python and don't require external packages
 
 # Background task scheduling
-apscheduler==3.10.4
+apscheduler==3.11.2
 
 # NEW: Cron expression support for recurring tasks
 croniter>=1.4.0
@@ -44,12 +44,12 @@ structlog==23.2.0
 # Development and testing
 pytest==9.0.3
 pytest-asyncio==0.21.1
-httpx==0.25.2
+httpx==0.28.1
 
 # Code quality
 black==26.3.1
-flake8==6.1.0
-isort==5.12.0
+flake8==7.3.0
+isort==8.0.1
 
 # Environment variable management
 python-dotenv==1.2.2
@@ -61,11 +61,11 @@ orjson==3.11.9
 python-dateutil==2.9.0.post0
 
 # AWS Bedrock support
-boto3==1.34.0
+boto3==1.43.6
 
 # Web scraping and HTML parsing
 beautifulsoup4==4.14.3
 lxml==6.1.0
 
 # RSS feed parsing
-feedparser==6.0.10
+feedparser==6.0.12


### PR DESCRIPTION
## Summary

Combines 8 Dependabot dep bumps into one PR so they can be reviewed and merged together (instead of 10 separate PRs cluttering the dashboard).

Bumps included (closes #66, #67, #69, #70, #71, #72, #74, #75):

| Package | From | To |
|---|---|---|
| boto3 | 1.34.0 | 1.43.6 |
| flake8 | 6.1.0 | 7.3.0 |
| python-multipart | 0.0.27 | 0.0.28 |
| apscheduler | 3.10.4 | 3.11.2 |
| isort | 5.12.0 | 8.0.1 |
| jsonschema | 4.21.1 | 4.26.0 |
| feedparser | 6.0.10 | 6.0.12 |
| httpx | 0.25.2 | 0.28.1 |

## Intentionally excluded

Two Dependabot PRs are left open because they depend on a coordinated pydantic bump that should be a separate decision:

- **#73** \`fastapi 0.104.1 -> 0.136.1\` — requires \`pydantic>=2.9.0\`, repo pins \`pydantic==2.5.1\`
- **#68** \`pydantic-settings 2.1.0 -> 2.14.1\` — requires \`pydantic>=2.7.0\`

## Test plan

- [x] \`uv pip install -r requirements.txt\` under Python 3.11 (matches Dockerfile) succeeds
- [x] \`python -c "import main"\` from \`agentic_ai_framework/\` loads without error (web UI mount, LLM manager init, etc. all log normally)
- [x] Pre-existing test collection errors on \`main\` are unchanged on this branch (failures are unrelated stale test imports, not caused by the bumps)