### PR TITLE
deps: bump fastapi, pydantic, pydantic-settings together

### DIFF
--- a/agentic_ai_framework/requirements.txt
+++ b/agentic_ai_framework/requirements.txt
@@ -1,7 +1,7 @@
 # Open Agentic Framework - Python Dependencies (Multi-Provider LLM Support)
 
 # FastAPI and ASGI server
-fastapi==0.104.1
+fastapi==0.136.1
 uvicorn[standard]==0.24.0
 aiofiles==23.2.1
 
@@ -14,8 +14,8 @@ aiohttp>=3.13.5
 requests==2.32.4
 
 # Data validation and serialization
-pydantic==2.5.1
-pydantic-settings==2.1.0
+pydantic==2.13.4
+pydantic-settings==2.14.1
 jsonschema==4.26.0
 
 # File upload and form handling


### PR DESCRIPTION
## Summary

Resolves the coordinated pydantic bump that was held back from #76 (closes #68, #73):

| Package | From | To | Reason |
|---|---|---|---|
| fastapi | 0.104.1 | 0.136.1 | Dependabot #73 |
| pydantic-settings | 2.1.0 | 2.14.1 | Dependabot #68 |
| pydantic | 2.5.1 | 2.13.4 | needed by both |

\`fastapi==0.136.1\` requires \`pydantic>=2.9\` and \`pydantic-settings==2.14.1\` requires \`pydantic>=2.7\`. \`pydantic==2.13.4\` satisfies both and is the latest 2.x release line.

\`starlette\` also moves \`0.27 -> 1.0\` as a transitive fastapi dep (not pinned in \`requirements.txt\`).

## Test plan

- [x] \`uv pip install -r requirements.txt\` under Python 3.11 succeeds with the new versions
- [x] \`python -c "import main"\` from \`agentic_ai_framework/\` loads without error (web UI mount, LLM provider manager, memory manager, tool manager, agent manager, workflow manager, model warmup manager all log normally)
- [x] No pydantic v1-style APIs broken — the 2.5 → 2.13 jump is within v2, and the import smoke test exercises all manager modules